### PR TITLE
Fix 'Open Localization' button visual, Up version to 1.0.6

### DIFF
--- a/Editor/GUI/LocalizationButtonDrawer.cs
+++ b/Editor/GUI/LocalizationButtonDrawer.cs
@@ -19,9 +19,12 @@ namespace DGGLocalization.Editor.GUI
         
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
-            EditorGUI.PropertyField(position, property, label);
+            var propertyHeight = EditorGUI.GetPropertyHeight(property);
+            var propertyRect = new Rect(position.x, position.y, position.width, propertyHeight);
             
-            var buttonRect = new Rect(position.x, position.y + EditorGUI.GetPropertyHeight(property) + Padding, position.width, ButtonHeight);
+            EditorGUI.PropertyField(propertyRect, property, label);
+            
+            var buttonRect = new Rect(position.x, position.y + propertyHeight + Padding, position.width, ButtonHeight);
 
             if (!UnityEngine.GUI.Button(buttonRect, "Open Localization")) return;
             

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.dark_dgg.dgglocalization",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "displayName": "DGG Localization",
   "description": "Package for localization",
   "unity": "2020.3",


### PR DESCRIPTION
The first time, I didn't take into account that the text would stretch to the full height.